### PR TITLE
Refactor: Convert C# DTOs from struct to record

### DIFF
--- a/halloween-kinect-mirror/godot_ui/GlobalClass.cs
+++ b/halloween-kinect-mirror/godot_ui/GlobalClass.cs
@@ -3,19 +3,19 @@ using System.Text.Json;
 using System.Collections.Generic;
 using System.Linq;
 
-public struct Frame
+public record Frame
 {
 	public IList<Body> bodies { get; init; }
 }
 
-public struct Body
+public record Body
 {
 	public int bodyIndex { get; init; }
 	public bool tracked { get; init; }
 	public IList<Joint> joints { get; init; }
 }
 
-public struct Joint
+public record Joint
 {
 	public int jointType { get; init; }
 	public float cameraX { get; init; }


### PR DESCRIPTION
I changed Frame, Body, and Joint types in GlobalClass.cs from 'struct' to 'record'.

This change aligns with modern C# best practices for Data Transfer Objects (DTOs), offering:
- Clearer intent: Records are designed for data-carrying purposes.
- Immutability: Maintained via 'init' properties, idiomatic for records.
- Reference type semantics: More suitable for potentially complex/nested DTOs, avoiding struct copying overhead.
- Built-in utilities: Compiler-generated Equals, GetHashCode, ToString for easier debugging and potential future use.

The functional behavior of data deserialization and access remains unchanged.